### PR TITLE
feat: Valentine's Dayを無効化

### DIFF
--- a/files/rewrite/data/scripts/biome_scripts.lua
+++ b/files/rewrite/data/scripts/biome_scripts.lua
@@ -1,0 +1,8 @@
+local function rewrite(replaceIfValid, hash)
+  -- ハートのスポーン率
+  replaceIfValid("data/scripts/biome_scripts.lua", hash, "( month == 2 ) and ( day == 14 )", "false")
+end
+
+return {
+  rewrite = rewrite,
+}

--- a/files/rewrite/data/scripts/items/potion.lua
+++ b/files/rewrite/data/scripts/items/potion.lua
@@ -1,0 +1,8 @@
+local function rewrite(replaceIfValid, hash)
+  -- フェロモンのスポーン率
+  replaceIfValid("data/scripts/items/potion.lua", hash, "month == 2 and day == 14", "false")
+end
+
+return {
+  rewrite = rewrite,
+}

--- a/files/rewrite/entry.lua
+++ b/files/rewrite/entry.lua
@@ -1,5 +1,6 @@
 local CONSTS = dofile_once("mods/noita-streak-explorer/files/scripts/const.lua")
 local glass_cannon_enemy = dofile_once("mods/noita-streak-explorer/files/rewrite/scripts/perks/glass_cannon_enemy.lua")
+local holiday_effects = dofile_once("mods/noita-streak-explorer/files/rewrite/events/holiday_effects.lua")
 
 local function rewrite()
   -- NOTE: ガラスキャノンの修正
@@ -9,6 +10,15 @@ local function rewrite()
   end
   if should_glass_cannon_fix then
     glass_cannon_enemy.rewrite()
+  end
+
+  -- NOTE: ホリデーイベント無効化
+  local disable_holiday_effects = ModSettingGet(CONSTS.MOD_SETTINGS.DISABLE_HOLIDAY_EFFECTS)
+  if disable_holiday_effects == nil then
+    disable_holiday_effects = false
+  end
+  if disable_holiday_effects then
+    holiday_effects.rewrite()
   end
 end
 

--- a/files/rewrite/events/holiday_effects.lua
+++ b/files/rewrite/events/holiday_effects.lua
@@ -1,0 +1,47 @@
+-- borrowed from time travel mod
+-- https://steamcommunity.com/sharedfiles/filedetails/?id=2937008418&searchtext=travel
+local function replaceIfValid(file, expectedHash, from, to)
+  local content = ModTextFileGetContent(file)
+  if not content then
+    error(table.concat({ "INJECTION (REPLACE) FAILED: NO FILE/nFile: ", file, "/nFrom: ", from, "/nTo: ", to }))
+    return
+  end
+
+  local md5 = dofile_once("mods/noita-streak-explorer/libs/md5/md5.lua")
+  local result = md5.sumhexa(content)
+  local valid = result == expectedHash
+  if not valid then
+    error(table.concat({ "INJECTION (REPLACE) FAILED: INVALID HASH/nFile: ", file, "/nFrom: ", from, "/nTo: ", to }))
+    return
+  end
+
+	local first, last = content:find(from, 0, true)
+  if not first then
+		error(table.concat({ "INJECTION (REPLACE) FAILED: NO HOOK/nFile: ", file, "/nFrom: ", from, "/nTo: ", to }))
+		return
+	end
+
+	local before = content:sub(1, first - 1)
+	local after = content:sub(last + 1)
+	local new = before .. to .. after
+  if content == new then
+    error(table.concat({ "INJECTION (REPLACE) FAILED: NO CHANGE/nFile: ", file, "/nFrom: ", from, "/nTo: ", to }))
+    return
+  end
+
+  ModTextFileSetContent(file, new)
+end
+
+local function rewrite()
+  local hash = dofile_once("mods/noita-streak-explorer/files/rewrite/hash.lua")
+
+  -- バレンタインデー無効化
+  dofile_once("mods/noita-streak-explorer/files/rewrite/data/scripts/biome_scripts.lua").rewrite(replaceIfValid, hash.biome_scripts)
+  dofile_once("mods/noita-streak-explorer/files/rewrite/data/scripts/items/potion.lua").rewrite(replaceIfValid, hash.potion)
+
+  --TODO バレンタインデー以外の無効化を実装する
+end
+
+return {
+  rewrite = rewrite,
+}

--- a/files/rewrite/hash.lua
+++ b/files/rewrite/hash.lua
@@ -1,3 +1,5 @@
 return {
   glass_cannon_enemy = "c9a1546cd5774981155124f6e38d2c97",
+  biome_scripts = "352b70bbc22ade4937d1c4248e23670e",
+  potion = "cf34fb939d471476e34163b4afaaac10",
 }

--- a/files/scripts/const.lua
+++ b/files/scripts/const.lua
@@ -3,5 +3,6 @@ local mod_name = "noita-streak-explorer"
 return {
   MOD_SETTINGS = {
     FIX_GLASS_CANNON_ENEMY = mod_name .. ".option.fix_glass_cannon_enemy",
+    DISABLE_HOLIDAY_EFFECTS = mod_name .. ".option.disable_holiday_effects",
   },
 }

--- a/settings.lua
+++ b/settings.lua
@@ -69,6 +69,15 @@ local settings_text = {
       ja = "敵パーク「ガラスキャノン」は倍率計算が間違っている可能性が高いため、\n本来想定されていたであろう値に修正します。\nまた、汚れ等の読み込まれていなかったオプションも適応させます。",
     },
   },
+  disable_holiday_effects = {
+    ui_name = {
+      ja = "季節イベントを無効化する",
+    },
+    -- TODO 他のイベントも記載する
+    ui_description = {
+      ja = "次のイベントを無効化します。\n2月14日 バレンタインデー",
+    },
+  },
 }
 
 local function mod_setting_change_game_mode_callback(_mod_id, _gui, _in_main_menu, _game_mode_setting, _old_mode_name, new_mode_name)
@@ -97,6 +106,14 @@ mod_settings = {
     id = "option.fix_glass_cannon_enemy",
     ui_name = settings_text.fix_glass_cannon_enemy.ui_name[language()],
     ui_description = settings_text.fix_glass_cannon_enemy.ui_description[language()],
+    value_default = false,
+    scope = MOD_SETTING_SCOPE_NEW_GAME,
+    hidden = true,
+  },
+  {
+    id = "option.disable_holiday_effects",
+    ui_name = settings_text.disable_holiday_effects.ui_name[language()],
+    ui_description = settings_text.disable_holiday_effects.ui_description[language()],
     value_default = false,
     scope = MOD_SETTING_SCOPE_NEW_GAME,
     hidden = true,


### PR DESCRIPTION
#33 での指摘受け、次のとおり修正しています
holiday_effects.lua
- errorはerror関数を使うようにしました。メッセージ内容も修正
- replace関数の名前、引数名を実情に沿うようにしました
- replace関数外出し
- 不要なコメント削除
- replace関数内のエラーチェックの順番おかしかったのを修正
- gsub関数のかわりにsub関数使う処理（time travel modで採用されている処理方法）に変えています
（上記エラーチェック順修正の後、もともとのgsub使う処理がうごいてなかったのを発見したため・・・すいません）

フォルダ構成変更にともなうdofileのパス変更実施しました。

biome_scripts.luaとpotion.luaをとりあえず作りました。holiday_effects.luaから呼ぶかたちにしています（他の季節イベント無効化でも同じ文字列置換処理を使いまわしたい）